### PR TITLE
Replaced `idempotentDeploy` with `deployAndGetContract`

### DIFF
--- a/deploy/v1/bsc-pancakeswap-2.js
+++ b/deploy/v1/bsc-pancakeswap-2.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 const ORACLES = {
     pancakeswapV2: {
@@ -17,12 +15,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const pancakeV2Oracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.pancakeswapV2.factory, ORACLES.pancakeswapV2.initHash],
+    const pancakeV2Oracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.pancakeswapV2.factory, ORACLES.pancakeswapV2.initHash],
         deployments,
         deployer,
-    );
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/deploy-apeswap-bsc.js
+++ b/deploy/v1/deploy-apeswap-bsc.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 const ORACLES = {
     Apeswap: {
@@ -17,12 +15,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const apeOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Apeswap.factory, ORACLES.Apeswap.initHash],
+    const apeOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Apeswap.factory, ORACLES.Apeswap.initHash],
         deployments,
         deployer,
-    );
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/deploy-arbitrum.js
+++ b/deploy/v1/deploy-arbitrum.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { tokens } = require('../../test/helpers.js');
-const {
-    idempotentDeploy,
-} = require('../utils.js');
 
 const WETH = '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1';
 
@@ -33,46 +30,46 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const wethWrapper = await idempotentDeploy(
-        'BaseCoinWrapper',
-        [WETH],
+    const wethWrapper = await deployAndGetContract({
+        contractName: 'BaseCoinWrapper',
+        constructorArgs: [WETH],
         deployments,
         deployer,
-    );
+    });
 
-    const multiWrapper = await idempotentDeploy(
-        'MultiWrapper',
-        [[wethWrapper.address]],
+    const multiWrapper = await deployAndGetContract({
+        contractName: 'MultiWrapper',
+        constructorArgs: [[wethWrapper.address]],
         deployments,
         deployer,
-    );
+    });
 
-    const uniswapV3Oracle = await idempotentDeploy(
-        'UniswapV3Oracle',
-        [ORACLES.UniV3.initHash],
+    const uniswapV3Oracle = await deployAndGetContract({
+        contractName: 'UniswapV3Oracle',
+        constructorArgs: [ORACLES.UniV3.initHash],
         deployments,
         deployer,
-    );
+    });
 
-    const swaprOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Swapr.factory, ORACLES.Swapr.initHash],
+    const swaprOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Swapr.factory, ORACLES.Swapr.initHash],
         deployments,
         deployer,
-        'UniswapV2LikeOracle',
-    );
+        deploymentName: 'UniswapV2LikeOracle',
+    });
 
-    const sushiOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Sushi.factory, ORACLES.Sushi.initHash],
+    const sushiOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Sushi.factory, ORACLES.Sushi.initHash],
         deployments,
         deployer,
-        'UniswapV2LikeOracle',
-    );
+        deploymentName: 'UniswapV2LikeOracle',
+    });
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [
             multiWrapper,
             [
                 sushiOracle.address,
@@ -89,7 +86,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         ],
         deployments,
         deployer,
-    );
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/deploy-aurora.js
+++ b/deploy/v1/deploy-aurora.js
@@ -1,11 +1,7 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { tokens } = require('../../test/helpers.js');
-const {
-    idempotentDeploy,
-    idempotentDeployGetContract,
-    deployCompoundTokenWrapper,
-} = require('../utils.js');
+const { deployCompoundTokenWrapper } = require('../utils.js');
 
 const cETHbastion = '0x4E8fE8fd314cFC09BDb0942c5adCC37431abDCD0';
 const auETHaurigami = '0xca9511B610bA5fc7E311FDeF9cE16050eE4449E9';
@@ -60,29 +56,58 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const baseCoinWrapper = await idempotentDeploy('BaseCoinWrapper', [WETH], deployments, deployer);
+    const baseCoinWrapper = await deployAndGetContract({
+        contractName: 'BaseCoinWrapper',
+        constructorArgs: [WETH],
+        deployments,
+        deployer,
+    });
     const bastionWrapper = await deployCompoundTokenWrapper(WRAPPERS.compound.bastion, cETHbastion, deployments, deployer);
     const aurigamiWrapper = await deployCompoundTokenWrapper(WRAPPERS.compound.aurigami, auETHaurigami, deployments, deployer);
 
-    const multiWrapper = await idempotentDeployGetContract(
-        'MultiWrapper',
-        [[
+    const multiWrapper = await deployAndGetContract({
+        contractName: 'MultiWrapper',
+        constructorArgs: [[
             baseCoinWrapper.address,
             bastionWrapper.address,
             aurigamiWrapper.address,
         ]],
         deployments,
         deployer,
-    );
+    });
 
-    const trisolaris = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.Trisolaris.factory, ORACLES.Trisolaris.initHash], deployments, deployer, 'UniswapV2LikeOracle_Trisolaris');
-    const wannaSwap = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.WannaSwap.factory, ORACLES.WannaSwap.initHash], deployments, deployer, 'UniswapV2LikeOracle_WannaSwap');
-    const nearPAD = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.NearPAD.factory, ORACLES.NearPAD.initHash], deployments, deployer, 'UniswapV2LikeOracle_NearPAD');
-    const auroraSwap = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.AuroraSwap.factory, ORACLES.AuroraSwap.initHash], deployments, deployer, 'UniswapV2LikeOracle_AuroraSwap');
+    const trisolaris = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Trisolaris.factory, ORACLES.Trisolaris.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_Trisolaris',
+    });
+    const wannaSwap = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.WannaSwap.factory, ORACLES.WannaSwap.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_WannaSwap',
+    });
+    const nearPAD = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.NearPAD.factory, ORACLES.NearPAD.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_NearPAD',
+    });
+    const auroraSwap = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.AuroraSwap.factory, ORACLES.AuroraSwap.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_AuroraSwap',
+    });
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [
             multiWrapper.address,
             [
                 trisolaris.address,
@@ -101,7 +126,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         ],
         deployments,
         deployer,
-    );
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/deploy-bsc.js
+++ b/deploy/v1/deploy-bsc.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { tokens } = require('../../test/helpers.js');
-const {
-    idempotentDeploy,
-} = require('../utils.js');
 
 const oracles = {
     pancakeswapOracle: '0xE295aD71242373C37C5FdA7B57F26f9eA1088AFe',
@@ -36,9 +33,9 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [
             multiWrapper,
             [
                 oracles.pancakeswapOracle,
@@ -63,7 +60,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         ],
         deployments,
         deployer,
-    );
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/deploy-chainlink-mainnet.js
+++ b/deploy/v1/deploy-chainlink-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running chainlink-mainnet deploy script');
@@ -12,12 +10,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 
-    const chainlinkOracle = await idempotentDeploy(
-        'ChainlinkOracle',
-        ['0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf'],
+    const chainlinkOracle = await deployAndGetContract({
+        contractName: 'ChainlinkOracle',
+        constructorArgs: ['0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf'],
         deployments,
         deployer,
-    );
+    });
 
     await (await offchainOracle.addOracle(chainlinkOracle.address, '1')).wait();
 };

--- a/deploy/v1/deploy-dfyn-matic.js
+++ b/deploy/v1/deploy-dfyn-matic.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 const ORACLES = {
     Dfyn: {
@@ -19,12 +17,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 
-    const dfynV2Oracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Dfyn.factory, ORACLES.Dfyn.initHash],
+    const dfynV2Oracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Dfyn.factory, ORACLES.Dfyn.initHash],
         deployments,
         deployer,
-    );
+    });
 
     await (await offchainOracle.addOracle(dfynV2Oracle.address, '0')).wait();
 };

--- a/deploy/v1/deploy-dmm-bsc.js
+++ b/deploy/v1/deploy-dmm-bsc.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running dmm-bsc deploy script');
@@ -12,12 +10,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 
-    const kyberDmmOracle = await idempotentDeploy(
-        'KyberDmmOracle',
-        ['0x878dFE971d44e9122048308301F540910Bbd934c'],
+    const kyberDmmOracle = await deployAndGetContract({
+        contractName: 'KyberDmmOracle',
+        constructorArgs: ['0x878dFE971d44e9122048308301F540910Bbd934c'],
         deployments,
         deployer,
-    );
+    });
 
     await (await offchainOracle.addOracle(kyberDmmOracle.address, '0')).wait();
 };

--- a/deploy/v1/deploy-dodo-aurora.js
+++ b/deploy/v1/deploy-dodo-aurora.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running dodo aurora deploy script');
@@ -15,18 +13,18 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const dodo = await idempotentDeploy(
-        'DodoOracle',
-        ['0xf50BDc9E90B7a1c138cb7935071b85c417C4cb8e'],
+    const dodo = await deployAndGetContract({
+        contractName: 'DodoOracle',
+        constructorArgs: ['0xf50BDc9E90B7a1c138cb7935071b85c417C4cb8e'],
         deployments,
         deployer,
-    );
-    const dodoV2 = await idempotentDeploy(
-        'DodoV2Oracle',
-        ['0x5515363c0412AdD5c72d3E302fE1bD7dCBCF93Fe'],
+    });
+    const dodoV2 = await deployAndGetContract({
+        contractName: 'DodoV2Oracle',
+        constructorArgs: ['0x5515363c0412AdD5c72d3E302fE1bD7dCBCF93Fe'],
         deployments,
         deployer,
-    );
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/deploy-fantom.js
+++ b/deploy/v1/deploy-fantom.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const {
-    idempotentDeploy,
-    idempotentDeployGetContract,
     deployCompoundTokenWrapper,
     addAaveTokens,
 } = require('../utils.js');
@@ -72,26 +70,60 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const screamWrapper = await deployCompoundTokenWrapper(WRAPPERS.compound.scream, SCREAM, deployments, deployer, 'CompoundLikeWrapper');
 
-    const baseCoinWrapper = await idempotentDeploy('BaseCoinWrapper', [AAWE_WRAPPER_TOKENS.wFTM], deployments, deployer);
-    const geistWrapper = await idempotentDeployGetContract('AaveWrapperV2', [WRAPPERS.aave.geist], deployments, deployer);
+    const baseCoinWrapper = await deployAndGetContract({
+        contractName: 'BaseCoinWrapper',
+        constructorArgs: [AAWE_WRAPPER_TOKENS.wFTM],
+        deployments,
+        deployer,
+    });
+    const geistWrapper = await deployAndGetContract({
+        contractName: 'AaveWrapperV2',
+        constructorArgs: [WRAPPERS.aave.geist],
+        deployments,
+        deployer,
+    });
 
     await addAaveTokens(geistWrapper, AAWE_WRAPPER_TOKENS);
 
-    const multiWrapper = await idempotentDeployGetContract(
-        'MultiWrapper',
-        [[
+    const multiWrapper = await deployAndGetContract({
+        contractName: 'MultiWrapper',
+        constructorArgs: [[
             baseCoinWrapper.address,
             geistWrapper.address,
             screamWrapper.address,
         ]],
         deployments,
         deployer,
-    );
+    });
 
-    const spookSywap = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.SpookySwap.factory, ORACLES.SpookySwap.initHash], deployments, deployer, 'UniswapV2LikeOracle_Spooky');
-    const solidex = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.Solidex.factory, ORACLES.Solidex.initHash], deployments, deployer, 'UniswapV2LikeOracle_Solidex');
-    const spiritSwap = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.SpiritSwap.factory, ORACLES.SpiritSwap.initHash], deployments, deployer, 'UniswapV2LikeOracle_SpiritSwap');
-    const sushiSwap = await idempotentDeploy('UniswapV2LikeOracle', [ORACLES.SushiSwap.factory, ORACLES.SushiSwap.initHash], deployments, deployer, 'UniswapV2LikeOracle_SushiSwap');
+    const spookSywap = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.SpookySwap.factory, ORACLES.SpookySwap.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_Spooky',
+    });
+    const solidex = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Solidex.factory, ORACLES.Solidex.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_Solidex',
+    });
+    const spiritSwap = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.SpiritSwap.factory, ORACLES.SpiritSwap.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_SpiritSwap',
+    });
+    const sushiSwap = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.SushiSwap.factory, ORACLES.SushiSwap.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'UniswapV2LikeOracle_SushiSwap',
+    });
 
     const args = [
         multiWrapper.address,
@@ -110,7 +142,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         CONNECTORS,
         AAWE_WRAPPER_TOKENS.wFTM,
     ];
-    const offchainOracle = await idempotentDeployGetContract('OffchainOracle', args);
+    const offchainOracle = await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: args,
+        deployments,
+        deployer,
+    });
     console.log('All oracles:', await offchainOracle.oracles());
     console.log('All connectors:', await offchainOracle.connectors());
 };

--- a/deploy/v1/deploy-klaytn-klayswap.js
+++ b/deploy/v1/deploy-klaytn-klayswap.js
@@ -1,9 +1,5 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
-const {
-    idempotentDeploy,
-    idempotentDeployGetContract,
-} = require('../utils.js');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 
 const ORACLES = {
     Klay: {
@@ -23,8 +19,18 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const klaySwap = await idempotentDeploy('KlaySwapOracle', [ORACLES.Klay.factory, ORACLES.Klay.storage], deployments, deployer);
-    const offchainOracle = await idempotentDeployGetContract('OffchainOracle', [], deployments, deployer);
+    const klaySwap = await deployAndGetContract({
+        contractName: 'KlaySwapOracle',
+        constructorArgs: [ORACLES.Klay.factory, ORACLES.Klay.storage],
+        deployments,
+        deployer,
+    });
+    const offchainOracle = await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [],
+        deployments,
+        deployer,
+    });
     await offchainOracle.addOracle(klaySwap.address, (toBN('0')).toString());
 };
 

--- a/deploy/v1/deploy-kyber-dmm-mainnet.js
+++ b/deploy/v1/deploy-kyber-dmm-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running kyber-dmm deploy script');
@@ -10,12 +8,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const kyberDmmOracle = await idempotentDeploy(
-        'KyberDmmOracle',
-        ['0x833e4083b7ae46cea85695c4f7ed25cdad8886de'],
+    const kyberDmmOracle = await deployAndGetContract({
+        contractName: 'KyberDmmOracle',
+        constructorArgs: ['0x833e4083b7ae46cea85695c4f7ed25cdad8886de'],
         deployments,
         deployer,
-    );
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/deploy-mainnet.js
+++ b/deploy/v1/deploy-mainnet.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { tokens } = require('../../test/helpers.js');
-const {
-    idempotentDeploy,
-} = require('../utils.js');
 
 const oracles = {
     uniswapV2Oracle: '0x8dc76c16e90351C1574a3Eea5c5797C475eA7292',
@@ -33,9 +30,9 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [
             multiWrapper,
             [
                 oracles.uniswapV2Oracle,
@@ -58,7 +55,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         ],
         deployments,
         deployer,
-    );
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/deploy-matic.js
+++ b/deploy/v1/deploy-matic.js
@@ -1,7 +1,5 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
 
 const QUICKSWAP_V2_FACTORY = '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32';
 const QUICKSWAP_V2_HASH = '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f';
@@ -15,41 +13,41 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const skipVerify = true;
 
-    const uniswapV2Oracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [QUICKSWAP_V2_FACTORY, QUICKSWAP_V2_HASH],
+    const uniswapV2Oracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [QUICKSWAP_V2_FACTORY, QUICKSWAP_V2_HASH],
         deployments,
         deployer,
-        'UniswapV2LikeOracle',
+        deploymentName: 'UniswapV2LikeOracle',
         skipVerify,
-    );
+    });
 
-    const wethWrapper = await idempotentDeploy(
-        'BaseCoinWrapper',
-        [WMATIC],
+    const wethWrapper = await deployAndGetContract({
+        contractName: 'BaseCoinWrapper',
+        constructorArgs: [WMATIC],
         deployments,
         deployer,
-        'BaseCoinWrapper',
+        deploymentName: 'BaseCoinWrapper',
         skipVerify,
-    );
+    });
 
-    const multiWrapper = await idempotentDeploy(
-        'MultiWrapper',
-        [[wethWrapper.address]],
+    const multiWrapper = await deployAndGetContract({
+        contractName: 'MultiWrapper',
+        constructorArgs: [[wethWrapper.address]],
         deployments,
         deployer,
-        'MultiWrapper',
+        deploymentName: 'MultiWrapper',
         skipVerify,
-    );
+    });
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [multiWrapper.address, [uniswapV2Oracle.address], []],
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [multiWrapper.address, [uniswapV2Oracle.address], []],
         deployments,
         deployer,
-        'OffchainOracle',
+        deploymentName: 'OffchainOracle',
         skipVerify,
-    );
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/deploy-ovm.js
+++ b/deploy/v1/deploy-ovm.js
@@ -1,7 +1,5 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
 
 const WETH = '0x4200000000000000000000000000000000000006';
 const NONE = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF';
@@ -14,32 +12,32 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const skipVerify = true;
 
-    const multiWrapper = await idempotentDeploy(
-        'MultiWrapper',
-        [[]],
+    const multiWrapper = await deployAndGetContract({
+        contractName: 'MultiWrapper',
+        constructorArgs: [[]],
         deployments,
         deployer,
-        'MultiWrapper',
+        deploymentName: 'MultiWrapper',
         skipVerify,
-    );
+    });
 
-    const uniswapV3Oracle = await idempotentDeploy(
-        'UniswapV3Oracle',
-        [],
+    const uniswapV3Oracle = await deployAndGetContract({
+        contractName: 'UniswapV3Oracle',
+        constructorArgs: [],
         deployments,
         deployer,
-        'UniswapV3Oracle',
+        deploymentName: 'UniswapV3Oracle',
         skipVerify,
-    );
+    });
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [multiWrapper.address, [uniswapV3Oracle.address], ['0'], [NONE, WETH], WETH],
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [multiWrapper.address, [uniswapV3Oracle.address], ['0'], [NONE, WETH], WETH],
         deployments,
         deployer,
-        'OffchainOracle',
+        deploymentName: 'OffchainOracle',
         skipVerify,
-    );
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/deploy-shibaswap-mainnet.js
+++ b/deploy/v1/deploy-shibaswap-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 const SHIBA_FACTORY = '0x115934131916c8b277dd010ee02de363c09d037c';
 const SHIBA_HASH = '0x65d1a3b1e46c6e4f1be1ad5f99ef14dc488ae0549dc97db9b30afe2241ce1c7a';
@@ -19,13 +17,13 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const shibaOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [SHIBA_FACTORY, SHIBA_HASH],
+    const shibaOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [SHIBA_FACTORY, SHIBA_HASH],
         deployments,
         deployer,
-        'UniswapV2LikeOracle_Shibaswap',
-    );
+        deploymentName: 'UniswapV2LikeOracle_Shibaswap',
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/deploy-solidly-fantom.js
+++ b/deploy/v1/deploy-solidly-fantom.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
-const { toBN } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { assertRoughlyEqualValues } = require('../../test/helpers.js');
 
 const ORACLES = {
@@ -76,7 +73,13 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     await getPrices(offchainOracle, 'without Solidly oracle');
 
     // Deploy and add solidly oracle
-    const solidly = await idempotentDeploy('SolidlyOracle', [ORACLES.Solidly.factory, ORACLES.Solidly.initHash], deployments, deployer, 'SolidlyOracle');
+    const solidly = await deployAndGetContract({
+        contractName: 'SolidlyOracle',
+        constructorArgs: [ORACLES.Solidly.factory, ORACLES.Solidly.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'SolidlyOracle',
+    });
     console.log('SolidlyOracle address: ', solidly.address);
 
     await offchainOracle.addOracle(solidly.address, (toBN('0')).toString());

--- a/deploy/v1/deploy-synthetix-mainnet.js
+++ b/deploy/v1/deploy-synthetix-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running synthetix-mainnet deploy script');
@@ -10,12 +8,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const synthetixOracle = await idempotentDeploy(
-        'SynthetixOracle',
-        ['0x4E3b31eB0E5CB73641EE1E65E7dCEFe520bA3ef2'],
+    const synthetixOracle = await deployAndGetContract({
+        contractName: 'SynthetixOracle',
+        constructorArgs: ['0x4E3b31eB0E5CB73641EE1E65E7dCEFe520bA3ef2'],
         deployments,
         deployer,
-    );
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/deploy-synthetix-optimistic.js
+++ b/deploy/v1/deploy-synthetix-optimistic.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running synthetix-optimistic deploy script');
@@ -10,14 +8,14 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const synthetixOracle = await idempotentDeploy(
-        'SynthetixOracle',
-        ['0x1Cb059b7e74fD21665968C908806143E744D5F30'],
+    const synthetixOracle = await deployAndGetContract({
+        contractName: 'SynthetixOracle',
+        constructorArgs: ['0x1Cb059b7e74fD21665968C908806143E744D5F30'],
         deployments,
         deployer,
-        'SynthetixOracle',
-        false, // skipVerify
-    );
+        deploymentName: 'SynthetixOracle',
+        skipVerify: false,
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/deploy-velodrome-finance-optimism.js
+++ b/deploy/v1/deploy-velodrome-finance-optimism.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
-const { toBN } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { assertRoughlyEqualValues } = require('../../test/helpers.js');
 
 const ORACLES = {
@@ -76,7 +73,13 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     await getPrices(offchainOracle, 'without VelodromeFinance oracle');
 
     // Deploy and add Velodrome-Finance oracle
-    const velodromeFinance = await idempotentDeploy('SolidlyOracle', [ORACLES.VelodromeFinance.factory, ORACLES.VelodromeFinance.initHash], deployments, deployer, 'VelodromeFinanceOracle');
+    const velodromeFinance = await deployAndGetContract({
+        contractName: 'SolidlyOracle',
+        constructorArgs: [ORACLES.VelodromeFinance.factory, ORACLES.VelodromeFinance.initHash],
+        deployments,
+        deployer,
+        deploymentName: 'VelodromeFinanceOracle',
+    });
     console.log('VelodromeFinanceOracle address: ', velodromeFinance.address);
 
     await offchainOracle.addOracle(velodromeFinance.address, (toBN('0')).toString());

--- a/deploy/v1/deploy-xdai.js
+++ b/deploy/v1/deploy-xdai.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { tokens } = require('../../test/helpers.js');
-const {
-    idempotentDeploy,
-} = require('../utils.js');
 
 const WXDAI = '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d';
 
@@ -36,54 +33,54 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const skipVerify = true;
 
-    const baseCoinWrapper = await idempotentDeploy(
-        'BaseCoinWrapper',
-        [WXDAI],
+    const baseCoinWrapper = await deployAndGetContract({
+        contractName: 'BaseCoinWrapper',
+        constructorArgs: [WXDAI],
         deployments,
         deployer,
-        'BaseCoinWrapper',
+        deploymentName: 'BaseCoinWrapper',
         skipVerify,
-    );
+    });
 
-    const multiWrapper = await idempotentDeploy(
-        'MultiWrapper',
-        [[baseCoinWrapper.address]],
+    const multiWrapper = await deployAndGetContract({
+        contractName: 'MultiWrapper',
+        constructorArgs: [[baseCoinWrapper.address]],
         deployments,
         deployer,
-        'MultiWrapper',
+        deploymentName: 'MultiWrapper',
         skipVerify,
-    );
+    });
 
-    const honeyswapOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Honey.factory, ORACLES.Honey.initHash],
+    const honeyswapOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Honey.factory, ORACLES.Honey.initHash],
         deployments,
         deployer,
-        'UniswapV2LikeOracle_Honeyswap',
+        deploymentName: 'UniswapV2LikeOracle_Honeyswap',
         skipVerify,
-    );
+    });
 
-    const levinswapOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Levin.factory, ORACLES.Levin.initHash],
+    const levinswapOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Levin.factory, ORACLES.Levin.initHash],
         deployments,
         deployer,
-        'UniswapV2LikeOracle_Levinswap',
+        deploymentName: 'UniswapV2LikeOracle_Levinswap',
         skipVerify,
-    );
+    });
 
-    const swaprOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Swapr.factory, ORACLES.Swapr.initHash],
+    const swaprOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Swapr.factory, ORACLES.Swapr.initHash],
         deployments,
         deployer,
-        'UniswapV2LikeOracle_Swapr',
+        deploymentName: 'UniswapV2LikeOracle_Swapr',
         skipVerify,
-    );
+    });
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [
             multiWrapper.address,
             [
                 honeyswapOracle.address,
@@ -100,9 +97,9 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         ],
         deployments,
         deployer,
-        'OffchainOracle',
+        deploymentName: 'OffchainOracle',
         skipVerify,
-    );
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/redeploy-matic.js
+++ b/deploy/v1/redeploy-matic.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-const { toBN } = require('@1inch/solidity-utils');
+const { deployAndGetContract, toBN } = require('@1inch/solidity-utils');
 const { tokens } = require('../../test/helpers.js');
-const {
-    idempotentDeploy,
-} = require('../utils.js');
 
 const oracles = {
     quickswapOracle: '0xE295aD71242373C37C5FdA7B57F26f9eA1088AFe',
@@ -25,9 +22,9 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    await idempotentDeploy(
-        'OffchainOracle',
-        [
+    await deployAndGetContract({
+        contractName: 'OffchainOracle',
+        constructorArgs: [
             multiWrapper,
             [
                 oracles.quickswapOracle,
@@ -44,9 +41,9 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         ],
         deployments,
         deployer,
-        'OffchainOracle',
-        true, // skipVerify
-    );
+        deploymentName: 'OffchainOracle',
+        skipVerify: true,
+    });
 };
 
 module.exports.skip = async () => true;

--- a/deploy/v1/redeploy-yvault-mainnet.js
+++ b/deploy/v1/redeploy-yvault-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 const OLD_YVAULT_WRAPPER = '0x910b9ba6a775e060a6f8dbee86f536a1e8f26021';
 
@@ -14,12 +12,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const multiWrapper = await getContract('MultiWrapper', deployments);
 
-    const yvaultWrapper = await idempotentDeploy(
-        'YVaultWrapper',
-        [],
+    const yvaultWrapper = await deployAndGetContract({
+        contractName: 'YVaultWrapper',
+        constructorArgs: [],
         deployments,
         deployer,
-    );
+    });
 
     await (await multiWrapper.removeWrapper(OLD_YVAULT_WRAPPER)).wait();
     await (await multiWrapper.addWrapper(yvaultWrapper.address)).wait();

--- a/deploy/v1/uniswap-v3-mainnet.js
+++ b/deploy/v1/uniswap-v3-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running uniswap-v3-mainnet deploy script');
@@ -10,12 +8,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const uniswapV3Oracle = await idempotentDeploy(
-        'UniswapV3Oracle',
-        ['0x1F98431c8aD98523631AE4a59f267346ea31F984', ['500', '3000', '10000']],
+    const uniswapV3Oracle = await deployAndGetContract({
+        contractName: 'UniswapV3Oracle',
+        constructorArgs: ['0x1F98431c8aD98523631AE4a59f267346ea31F984', ['500', '3000', '10000']],
         deployments,
         deployer,
-    );
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/update-chainlink-mainnet.js
+++ b/deploy/v1/update-chainlink-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running deploy script');
@@ -10,12 +8,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const { deployer } = await getNamedAccounts();
 
-    const chainlinkOracle = await idempotentDeploy(
-        'chainlinkOracle',
-        ['0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf'],
+    const chainlinkOracle = await deployAndGetContract({
+        contractName: 'chainlinkOracle',
+        constructorArgs: ['0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf'],
         deployments,
         deployer,
-    );
+    });
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
 

--- a/deploy/v1/update-matic-2.js
+++ b/deploy/v1/update-matic-2.js
@@ -1,8 +1,6 @@
 const { getChainId, ethers } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 const ORACLES = {
     Cometh: {
@@ -37,27 +35,27 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     const multiWrapper = await getContract('MultiWrapper', deployments);
     const offchainOracle = await getContract('OffchainOracle', deployments);
 
-    const cometh = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Cometh.factory, ORACLES.Cometh.initHash],
+    const cometh = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Cometh.factory, ORACLES.Cometh.initHash],
         deployments,
         deployer,
-    );
+    });
 
-    const sushi = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Sushi.factory, ORACLES.Sushi.initHash],
+    const sushi = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Sushi.factory, ORACLES.Sushi.initHash],
         deployments,
         deployer,
-    );
+    });
 
     const AaveWrapperV2 = await ethers.getContractFactory('AaveWrapperV2');
-    const aaveDeployment = await idempotentDeploy(
-        'AaveWrapperV2',
-        [ORACLES.Aave.letdingPool],
+    const aaveDeployment = await deployAndGetContract({
+        contractName: 'AaveWrapperV2',
+        constructorArgs: [ORACLES.Aave.letdingPool],
         deployments,
         deployer,
-    );
+    });
     const aave = AaveWrapperV2.attach(aaveDeployment.address);
 
     await (await offchainOracle.addOracle(cometh.address, '0')).wait();

--- a/deploy/v1/update-uniswap-v3.js
+++ b/deploy/v1/update-uniswap-v3.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running uniswap-v3 deploy script');
@@ -13,15 +11,14 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     const offchainOracle = await getContract('OffchainOracle', deployments);
     const oldUniswapV3Oracle = await getContract('UniswapV3Oracle', deployments);
 
-    const uniswapV3Oracle = await idempotentDeploy(
-        'UniswapV3Oracle',
-        [],
+    const uniswapV3Oracle = await deployAndGetContract({
+        contractName: 'UniswapV3Oracle',
+        constructorArgs: [],
         deployments,
         deployer,
-        'UniswapV3Oracle',
-        false,
-        false,
-    );
+        deploymentName: 'UniswapV3Oracle',
+        skipIfAlreadyDeployed: false,
+    });
 
     await (await offchainOracle.removeOracle(oldUniswapV3Oracle.address, '0')).wait();
     await (await offchainOracle.addOracle(uniswapV3Oracle.address, '0')).wait();

--- a/deploy/v1/update-xdai.js
+++ b/deploy/v1/update-xdai.js
@@ -1,9 +1,6 @@
 const { getChainId } = require('hardhat');
-
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 const WETH = '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1';
 const HONEY = '0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9';
@@ -43,23 +40,21 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     await (await offchainOracle.removeOracle((await deployments.get('UniswapV2LikeOracle_Honeyswap')).address, '0')).wait();
 
-    const honeyswapOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Honey.factory, ORACLES.Honey.initHash],
+    const honeyswapOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Honey.factory, ORACLES.Honey.initHash],
         deployments,
         deployer,
-        'UniswapV2LikeOracle_Honeyswap',
-        false, // skipVerify
-    );
+        deploymentName: 'UniswapV2LikeOracle_Honeyswap',
+    });
 
-    const sushiswapOracle = await idempotentDeploy(
-        'UniswapV2LikeOracle',
-        [ORACLES.Sushi.factory, ORACLES.Sushi.initHash],
+    const sushiswapOracle = await deployAndGetContract({
+        contractName: 'UniswapV2LikeOracle',
+        constructorArgs: [ORACLES.Sushi.factory, ORACLES.Sushi.initHash],
         deployments,
         deployer,
-        'UniswapV2LikeOracle_Sushiswap',
-        false, // skipVerify
-    );
+        deploymentName: 'UniswapV2LikeOracle_Sushiswap',
+    });
 
     await (await offchainOracle.addOracle(honeyswapOracle.address, '0')).wait();
     await (await offchainOracle.addOracle(sushiswapOracle.address, '0')).wait();

--- a/deploy/v1/yvault-mainnet.js
+++ b/deploy/v1/yvault-mainnet.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     console.log('running yvault deploy script');
@@ -12,12 +10,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
     const multiWrapper = await getContract('MultiWrapper', deployments);
 
-    const yvaultWrapper = await idempotentDeploy(
-        'YVaultWrapper',
-        [],
+    const yvaultWrapper = await deployAndGetContract({
+        contractName: 'YVaultWrapper',
+        constructorArgs: [],
         deployments,
         deployer,
-    );
+    });
 
     await (await multiWrapper.addWrapper(yvaultWrapper.address)).wait();
 };

--- a/deploy/v2/deploy-oracle.js
+++ b/deploy/v2/deploy-oracle.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const PARAMS = {
@@ -18,15 +16,13 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     const { deployer } = await getNamedAccounts();
 
     const offchainOracle = await getContract('OffchainOracle', deployments);
-    const customOracle = await idempotentDeploy(
-        PARAMS.contractName,
-        PARAMS.args,
+    const customOracle = await deployAndGetContract({
+        contractName: PARAMS.contractName,
+        constructorArgs: PARAMS.args,
         deployments,
         deployer,
-        PARAMS.deploymentName,
-        false,
-        true,
-    );
+        deploymentName: PARAMS.deploymentName,
+    });
     await offchainOracle.addOracle(customOracle.address, PARAMS.oracleType);
 };
 

--- a/deploy/v2/redeploy-oracle.js
+++ b/deploy/v2/redeploy-oracle.js
@@ -1,8 +1,6 @@
 const { getChainId } = require('hardhat');
-const {
-    idempotentDeploy,
-    getContract,
-} = require('../utils.js');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { getContract } = require('../utils.js');
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const PARAMS = {
@@ -22,15 +20,14 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     const oracles = await offchainOracle.oracles();
     const customOracleType = oracles.oracleTypes[oracles.allOracles.indexOf(oldCustomOracle.address)];
 
-    const customOracle = await idempotentDeploy(
-        PARAMS.contractName,
-        PARAMS.args,
+    const customOracle = await deployAndGetContract({
+        contractName: PARAMS.contractName,
+        constructorArgs: PARAMS.args,
         deployments,
         deployer,
-        PARAMS.deploymentName,
-        false,
-        false,
-    );
+        deploymentName: PARAMS.deploymentName,
+        skipIfAlreadyDeployed: false,
+    });
     await offchainOracle.removeOracle(oldCustomOracle.address, customOracleType);
     await offchainOracle.addOracle(customOracle.address, customOracleType);
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@openzeppelin/contracts": "4.9.0"
     },
     "devDependencies": {
-        "@1inch/solidity-utils": "2.2.27",
+        "@1inch/solidity-utils": "2.3.0",
         "@matterlabs/hardhat-zksync-deploy": "0.6.3",
         "@matterlabs/hardhat-zksync-solc": "0.3.17",
         "@matterlabs/hardhat-zksync-verify": "0.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@1inch/solidity-utils@2.2.27":
-  version "2.2.27"
-  resolved "https://registry.yarnpkg.com/@1inch/solidity-utils/-/solidity-utils-2.2.27.tgz#28a131304788674042dae002e817b2cd9346f232"
-  integrity sha512-rybgnA5Bd1+XRrAdIK3sNWWIMXZ5tWl4Ds4IwZVCzAXMLvxdXnJyb6zm//uuko9cRH63aDjct5Mzf+ggg36AJg==
+"@1inch/solidity-utils@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@1inch/solidity-utils/-/solidity-utils-2.3.0.tgz#5a3507419ec8b2fe801ccbe2281b4e2b9c39da83"
+  integrity sha512-UIV8Ip0R4S0hZc2VoPKxLShnN+kchWhNw1XhE48b/QS7msJNBdtaPDDTb+e7mgOVg9qf0gvHE6fFkzRRR67LQg==
   dependencies:
     "@metamask/eth-sig-util" "5.0.2"
     "@nomicfoundation/hardhat-network-helpers" "1.0.8"


### PR DESCRIPTION
Updated the `solidity-utils` version and used `deployAndGetContract` function instead of `idempotentDeploy` and `idempotentDeployGetContract` functions in the deployment scrips.