### PR TITLE
feat: support uniswap v4 backGeoOracle

### DIFF
--- a/contracts/interfaces/IUniswapV4StateView.sol
+++ b/contracts/interfaces/IUniswapV4StateView.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+struct PoolKey {
+    address currency0;
+    address currency1;
+    uint24 fee;
+    int24 tickSpacing;
+    address hooks;
+}
+
+interface IUniswapV4StateView {
+    function getSlot0(bytes32 poolId) external view returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee);
+    function getLiquidity(bytes32 poolId) external view returns (uint128 liquidity);
+    function getTickLiquidity(bytes32 poolId, int24 tick) external view returns (uint128 liquidityGross, int128 liquidityNet);
+}

--- a/contracts/oracles/UniswapV4BackGeoOracle.sol
+++ b/contracts/oracles/UniswapV4BackGeoOracle.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+import "../interfaces/IOracle.sol";
+import "../interfaces/IUniswapV4StateView.sol";
+import "../libraries/OraclePrices.sol";
+
+contract UniswapV4BackGeoOracle is IOracle {
+    using OraclePrices for OraclePrices.Data;
+    using Math for uint256;
+
+    IERC20 private constant _NONE = IERC20(0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF);
+
+    IUniswapV4StateView public immutable STATE_VIEW;
+
+    address public immutable BACK_GEO_ORACLE;
+
+    uint24 public constant FEE = 0;
+    int24 public constant MAX_TICK_SPACING = type(int16).max;
+    uint8 private constant _ONE = 1;
+
+    constructor(
+        IUniswapV4StateView _stateView,
+        address _backGeoOracle
+    ) {
+        STATE_VIEW = _stateView;
+        BACK_GEO_ORACLE = _backGeoOracle;
+    }
+
+    function getRate(
+        IERC20 srcToken,
+        IERC20 dstToken,
+        IERC20 connector,
+        uint256 thresholdFilter
+    ) external view override returns (uint256 rate, uint256 weight) {
+        if (connector != _NONE) revert ConnectorShouldBeNone();
+
+        OraclePrices.Data memory ratesAndWeights = OraclePrices.init(_ONE);
+
+        (uint256 r, uint256 w) = _getRateDirect(srcToken, dstToken, FEE, MAX_TICK_SPACING);
+        ratesAndWeights.append(OraclePrices.OraclePrice(r, w));
+
+        return ratesAndWeights.getRateAndWeight(thresholdFilter);
+    }
+
+    function _getRateDirect(
+        IERC20 srcToken,
+        IERC20 dstToken,
+        uint24 fee,
+        int24 tickSpacing
+    ) internal view returns (uint256 rate, uint256 liquidity) {
+        (IERC20 token0, IERC20 token1, bool zeroForOne) =
+            address(srcToken) < address(dstToken) ? (srcToken, dstToken, true) : (dstToken, srcToken, false);
+
+        bytes32 id = _toId(PoolKey({
+            currency0: address(token0),
+            currency1: address(token1),
+            fee: fee,
+            tickSpacing: tickSpacing,
+            hooks: BACK_GEO_ORACLE
+        }));
+
+        liquidity = uint256(STATE_VIEW.getLiquidity(id));
+        if (liquidity == 0) return (0, 0);
+
+        (uint160 sqrtPriceX96, int24 tick,,) = STATE_VIEW.getSlot0(id);
+        tick = (tick / tickSpacing) * tickSpacing;
+
+        int256 liquidityShiftsRight = int256(liquidity);
+        int256 liquidityShiftsLeft = int256(liquidity);
+
+        unchecked {
+            for (int24 i = 0; i <= _TICK_STEPS; i++) {
+                int256 nextTick = int256(tick) + int256(i) * int256(tickSpacing);
+                (, int128 liquidityNet) = STATE_VIEW.getTickLiquidity(id, tick + i * tickSpacing);
+                liquidityShiftsRight += liquidityNet;
+                liquidity = Math.min(liquidity, uint256(liquidityShiftsRight));
+                if (liquidityShiftsRight == 0) {
+                    return (0, 0);
+                }
+
+                nextTick = int256(tick) - int256(i) * int256(tickSpacing);
+                (, liquidityNet) = STATE_VIEW.getTickLiquidity(id, tick - i * tickSpacing);
+                liquidityShiftsLeft -= liquidityNet;
+                liquidity = Math.min(liquidity, uint256(liquidityShiftsLeft));
+                if (liquidityShiftsLeft == 0) {
+                    return (0, 0);
+                }
+            }
+        }
+
+        if (zeroForOne) {
+            // rate = (uint256(sqrtPriceX96) * uint256(sqrtPriceX96) * 1e18) >> 192;
+            rate = Math.mulDiv(
+                Math.mulDiv(uint256(sqrtPriceX96), uint256(sqrtPriceX96), 1 << 96),
+                1e18,
+                1 << 96
+            );
+        } else {
+            uint256 num = (1e18) << 192;
+            rate = num / uint256(sqrtPriceX96) / uint256(sqrtPriceX96);
+        }
+    }
+
+    /// @notice Returns value equal to keccak256(abi.encode(poolKey))
+    function _toId(PoolKey memory poolKey) internal pure returns (bytes32 poolId) {
+        assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
+            // 0xa0 represents the total size of the poolKey struct (5 slots of 32 bytes)
+            poolId := keccak256(poolKey, 0xa0)
+        }
+    }
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -102,6 +102,12 @@ const deployParams = {
         initcodeHash: '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54',
         fees: [100, 500, 3000, 10000],
     },
+    UniswapV4: {
+        stateView: '0x7ffe42c4a5deea5b0fec41c94c136cf115597227',
+        backGeoOracle: '0xB13250f0Dc8ec6dE297E81CDA8142DB51860BaC4',
+        fees: [100, 500, 3000, 10000],
+        tickSpacings: [1, 10, 60, 200],
+    },
     UniswapV3Base: { // base network
         factory: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',
         initcodeHash: '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54',

--- a/test/oracles/UniswapV4BackGeoOracle.js
+++ b/test/oracles/UniswapV4BackGeoOracle.js
@@ -1,0 +1,37 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { deployContract } = require('@1inch/solidity-utils');
+const {
+    tokens,
+    deployParams: { UniswapV2, UniswapV4 },
+    testRate,
+} = require('../helpers.js');
+
+describe('UniswapV4BackGeoOracle', function () {
+    async function initContracts () {
+        const uniswapV2LikeOracle = await deployContract('UniswapV2LikeOracle', [UniswapV2.factory, UniswapV2.initcodeHash]);
+        const uniswapV4BackGeoOracle = await deployContract('UniswapV4BackGeoOracle', [UniswapV4.stateView, UniswapV4.fees, UniswapV4.tickSpacings]);
+        return { uniswapV2LikeOracle, uniswapV4BackGeoOracle };
+    }
+
+    describe('UniswapV4', function () {
+        it('USDC -> USDT', async function () {
+            const { uniswapV2LikeOracle, uniswapV4BackGeoOracle } = await loadFixture(initContracts);
+            await testRate(tokens.USDC, tokens.USDT, tokens.NONE, uniswapV2LikeOracle, uniswapV4BackGeoOracle);
+        });
+
+        it('USDT -> USDC', async function () {
+            const { uniswapV2LikeOracle, uniswapV4BackGeoOracle } = await loadFixture(initContracts);
+            await testRate(tokens.USDT, tokens.USDC, tokens.NONE, uniswapV2LikeOracle, uniswapV4BackGeoOracle);
+        });
+
+        it('USDC -> WETH', async function () {
+            const { uniswapV2LikeOracle, uniswapV4BackGeoOracle } = await loadFixture(initContracts);
+            await testRate(tokens.USDC, tokens.WETH, tokens.NONE, uniswapV2LikeOracle, uniswapV4BackGeoOracle);
+        });
+
+        it('WETH -> USDC', async function () {
+            const { uniswapV2LikeOracle, uniswapV4BackGeoOracle } = await loadFixture(initContracts);
+            await testRate(tokens.WETH, tokens.USDC, tokens.NONE, uniswapV2LikeOracle, uniswapV4BackGeoOracle);
+        });
+    });
+});


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
<!-- Describe the changes in 1-2 sentences -->
Support the Uniswap V4 BackGeoOracle hook. It is implemented in the same way as the [UniswapV4LikeOracle](https://github.com/1inch/spot-price-aggregator/pull/226), thus reading from the `slot0` instead of using the oracle's `observe` method for simplicity. The oracle has a maximum tick delta within a single block, so it is safer from manipulation compared to other Uniswap pools.

**Related Issue/Ticket:**
<!-- Link to JIRA ticket, GitHub issue, or change request -->

## Testing & Verification
**How was this tested?**
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [ ] **Low** - Minor changes, no operational impact
- [x] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
<!-- Describe any possible risks, such as migrations, downtime, or breaking changes, etc. -->
Risk: `slot0` can be manipulated within certain tick deltas (max ≃15% price movement tolerance within a single block). An improved approach would be to use a 1-minute twap via the hook's `observe` method (still gas efficient).
